### PR TITLE
Update graphql listener

### DIFF
--- a/apps/graphql-api/app.js
+++ b/apps/graphql-api/app.js
@@ -1,23 +1,18 @@
 import express from "express";
 import { graphqlHTTP } from "express-graphql";
-import {
-  initDatabase,
-  addDataToDatabase,
-  dropAllTables,
-} from "./databaseSetup.js";
+import { initDatabase } from "./database/setup.js";
 import { schema } from "./schema.js";
 import cors from "cors";
+import { reloadOnFileChange } from "./middleware/reloader.js";
 
 const app = express();
 const corsOptions = { origin: "*" };
 app.use(cors(corsOptions));
 
-// dropAllTables();
 initDatabase();
-// addDataToDatabase();
 
-app.use("/graphql", graphqlHTTP({ schema: schema, graphiql: true }));
+app.use("/graphql", reloadOnFileChange, graphqlHTTP({ schema: schema, graphiql: true }));
 
 app.listen(5500, () => {
-  console.log("GraphQL server running at http://localhost:5500.");
+  console.log("[INFO]   GraphQL server running at http://localhost:5500.");
 });

--- a/apps/graphql-api/app.js
+++ b/apps/graphql-api/app.js
@@ -4,12 +4,14 @@ import { initDatabase } from "./database/setup.js";
 import { schema } from "./schema.js";
 import cors from "cors";
 import { reloadOnFileChange } from "./middleware/reloader.js";
+import { fixDbPermissions } from "./database/fixPermissions.js";
 
 const app = express();
 const corsOptions = { origin: "*" };
 app.use(cors(corsOptions));
 
 initDatabase();
+fixDbPermissions();
 
 app.use("/graphql", reloadOnFileChange, graphqlHTTP({ schema: schema, graphiql: true }));
 

--- a/apps/graphql-api/database/connection.js
+++ b/apps/graphql-api/database/connection.js
@@ -1,0 +1,26 @@
+import sqlite3 from "sqlite3";
+import { open } from "sqlite";
+
+const SFTP_USERNAME = process.env.SFTP_USERNAME;
+const filename = SFTP_USERNAME ? `/app/upload/products.db` : "products.db";
+
+class DatabaseConnection {
+  static async update() {
+    DatabaseConnection.connection = await open({
+      filename: filename,
+      driver: sqlite3.Database,
+    });
+  }
+
+  static async get() {
+    if (!DatabaseConnection.connection) {
+      DatabaseConnection.connection = await open({
+        filename: filename,
+        driver: sqlite3.Database,
+      });
+    }
+    return DatabaseConnection.connection;
+  }
+}
+
+export { DatabaseConnection };

--- a/apps/graphql-api/database/connection.js
+++ b/apps/graphql-api/database/connection.js
@@ -4,7 +4,18 @@ import { open } from "sqlite";
 const SFTP_USERNAME = process.env.SFTP_USERNAME;
 const filename = SFTP_USERNAME ? `/app/upload/products.db` : "products.db";
 
+/** Class to manage the DB connection in a singleton like  manner */
 class DatabaseConnection {
+  /**
+   * Constructor throws errors when called to prevent new instances of DatabaseConnection being created.
+   */
+  constructor() {
+    throw new Error("Use DatabaseConnection.get()");
+  }
+
+  /**
+   * Creates a new connection with the file from disk, and sets that connection to the class' connection attribute.
+   */
   static async update() {
     DatabaseConnection.connection = await open({
       filename: filename,
@@ -12,6 +23,13 @@ class DatabaseConnection {
     });
   }
 
+  /**
+   * Returns a database connection instance.
+   *
+   * If the instance does not exist, it creates it. If it does exist, it retrieves it instead.
+   * Ensures that there is only ever one instance of the connection.
+   * @returns {Promise<Database>} Database connection object
+   */
   static async get() {
     if (!DatabaseConnection.connection) {
       DatabaseConnection.connection = await open({

--- a/apps/graphql-api/database/fixPermissions.js
+++ b/apps/graphql-api/database/fixPermissions.js
@@ -1,0 +1,32 @@
+import fs from "fs";
+
+const fixDbPermissions = () => {
+  fs.stat("/app/upload/products.db", (err, stats) => {
+    if (err)
+      return console.log(
+        "File: 'products.db' does not exist yet.\nSkipping file permissions"
+      );
+
+    console.log("[DEBUG]  Setting current updatedAt value...");
+    global.productsDbUpdatedAtTime = stats.mtime.toISOString();
+
+    console.log(
+      "[DEBUG]  Set global.productsDbUpdatedAtTime to: ",
+      productsDbUpdatedAtTime
+    );
+    console.log("[DEBUG]  Checking for file permissions...");
+
+    const groupId = stats.uid;
+    console.log("[DEBUG]  Group id is: ", groupId);
+    if (groupId === 0) {
+      fs.chown("/app/upload/products.db", 1001, 0, (err) => {
+        if (err) console.log(err);
+
+        console.log("[DEBUG]  File permissions updated successfully");
+        console.log("[DEBUG]  Group id is now: ", 1001);
+      });
+    }
+  });
+};
+
+export { fixDbPermissions };

--- a/apps/graphql-api/database/fixPermissions.js
+++ b/apps/graphql-api/database/fixPermissions.js
@@ -1,5 +1,10 @@
 import fs from "fs";
-
+/**
+ * Function that checks and updates the owner id of the file.
+ * 
+ * If the file does not have the group id of `1001` it will set it to that.
+ * This ensures that the SFTP server is always able to overwrite it.
+ */
 const fixDbPermissions = () => {
   fs.stat("/app/upload/products.db", (err, stats) => {
     if (err)

--- a/apps/graphql-api/database/setup.js
+++ b/apps/graphql-api/database/setup.js
@@ -1,4 +1,3 @@
-import fs from "fs";
 import { DatabaseConnection } from "./connection.js"
 
 const SFTP_USERNAME = process.env.SFTP_USERNAME;
@@ -6,25 +5,9 @@ const filename = SFTP_USERNAME ? `/app/upload/products.db` : "products.db";
 
 console.log(`[INFO]   Using the db file: ${filename}`);
 
-fs.stat("/app/upload/products.db", (err, stats) => {
-  if (err) console.log(err);
-  console.log("[DEBUG]  Setting current updatedAt value...");
-  global.productsDbUpdatedAtTime = stats.mtime.toISOString();
-  console.log("[DEBUG]  Set global.productsDbUpdatedAtTime to: ", productsDbUpdatedAtTime);
-  console.log("[DEBUG]  Checking for file permissions...");
-  const groupId = stats.uid;
-  console.log("[DEBUG]  Group id is: ", groupId);
-  if (groupId === 0) {
-    fs.chown("/app/upload/products.db", 1001, 0, (err) => {
-      if (err) console.log(err);
-
-      console.log("[DEBUG]  File permissions updated successfully");
-    });
-  }
-});
-
 export async function initDatabase() {
   const database = await DatabaseConnection.get();
+  console.log("[TRACE]  Creating table if it does not exist: Products");
   database.exec(`
         CREATE TABLE IF NOT EXISTS Products (
             product_id integer PRIMARY KEY,
@@ -38,6 +21,7 @@ export async function initDatabase() {
             overall_rating text
         );
     `);
+  console.log("[TRACE]  Creating table if it does not exist: ProductImages");
   database.exec(`
         CREATE TABLE IF NOT EXISTS ProductImages (
             product_image_id integer PRIMARY KEY,
@@ -48,6 +32,7 @@ export async function initDatabase() {
             FOREIGN KEY (product_id) REFERENCES Products(product_id)
         );
     `);
+  console.log("[TRACE]  Creating table if it does not exist: ProductAdditionalInfos");
   database.exec(`
         CREATE TABLE IF NOT EXISTS ProductAdditionalInfos (
             product_additional_info_id integer PRIMARY KEY,
@@ -62,36 +47,36 @@ export async function initDatabase() {
 export async function addDataToDatabase() {
   const database = await DatabaseConnection.get();
   const args = {
-    product_name: "test1",
-    product_sub_title: "test1",
-    product_description: "test1",
-    main_category: "test1",
-    sub_category: "test1",
+    product_name: "replaced1",
+    product_sub_title: "replaced1",
+    product_description: "replaced1",
+    main_category: "replaced1",
+    sub_category: "replaced1",
     price: 123,
-    link: "test1",
-    overall_rating: "test1",
+    link: "replaced1",
+    overall_rating: "replaced1",
   };
   const argsOne = {
-    product_name: "test2",
-    product_sub_title: "test2",
-    product_description: "test2",
-    main_category: "test2",
-    sub_category: "test2",
+    product_name: "replaced2",
+    product_sub_title: "replaced2",
+    product_description: "replaced2",
+    main_category: "replaced2",
+    sub_category: "replaced2",
     price: 123,
-    link: "test2",
-    overall_rating: "test2",
+    link: "replaced2",
+    overall_rating: "replaced2",
   };
   const argsTwo = {
-    product_name: "test3",
-    product_sub_title: "test3",
-    product_description: "test3",
-    main_category: "test3",
-    sub_category: "test3",
+    product_name: "replaced3",
+    product_sub_title: "replaced3",
+    product_description: "replaced3",
+    main_category: "replaced3",
+    sub_category: "replaced3",
     price: 123,
-    link: "test3",
-    overall_rating: "test3",
+    link: "replaced3",
+    overall_rating: "replaced3",
   };
-
+  console.log("[TRACE]  Adding seeding data to Products 1/3...");
   const result = await database.run(
     `INSERT INTO Products (product_name, product_sub_title, product_description, main_category, sub_category, price, link, overall_rating) VALUES (?,?,?,?,?,?,?,?)`,
     [
@@ -105,6 +90,7 @@ export async function addDataToDatabase() {
       args.overall_rating,
     ]
   );
+  console.log("[TRACE]  Adding seeding data to Products 2/3...");
   const result1 = await database.run(
     `INSERT INTO Products (product_name, product_sub_title, product_description, main_category, sub_category, price, link, overall_rating) VALUES (?,?,?,?,?,?,?,?)`,
     [
@@ -118,6 +104,7 @@ export async function addDataToDatabase() {
       argsOne.overall_rating,
     ]
   );
+  console.log("[TRACE]  Adding seeding data to Products 3/3...");
   const result2 = await database.run(
     `INSERT INTO Products (product_name, product_sub_title, product_description, main_category, sub_category, price, link, overall_rating) VALUES (?,?,?,?,?,?,?,?)`,
     [
@@ -133,28 +120,34 @@ export async function addDataToDatabase() {
   );
   console.log(result, result1, result2);
 
+  console.log("[TRACE]  Adding seeding data to ProductsImages 1/3...");
   const result3 = await database.run(
     `INSERT INTO ProductImages (product_id, image_url, alt_text, additional_info) VALUES (?,?,?,?)`,
     ["1", "imgArgs.image_url", "imgArgs.alt_text", "imgArgs.additional_info"]
   );
+  console.log("[TRACE]  Adding seeding data to ProductsImages 2/3...");
   const result4 = await database.run(
     `INSERT INTO ProductImages (product_id, image_url, alt_text, additional_info) VALUES (?,?,?,?)`,
     ["2", "imgArgs.image_url2", "imgArgs.alt_text2", "imgArgs.additional_info2"]
   );
+  console.log("[TRACE]  Adding seeding data to ProductsImages 3/3...");
   const result5 = await database.run(
     `INSERT INTO ProductImages (product_id, image_url, alt_text, additional_info) VALUES (?,?,?,?)`,
     ["3", "imgArgs.image_url3", "imgArgs.alt_text3", "imgArgs.additional_info3"]
   );
   console.log(result3, result4, result5);
 
+  console.log("[TRACE]  Adding seeding data to ProductAdditionalInfos 1/3...");
   const result6 = await database.run(
     `INSERT INTO ProductAdditionalInfos (product_id, choices, additional_info) VALUES (?,?,?)`,
     ["1", "choices", "additional info stuff"]
   );
+  console.log("[TRACE]  Adding seeding data to ProductAdditionalInfos 2/3...");
   const result7 = await database.run(
     `INSERT INTO ProductAdditionalInfos (product_id, choices, additional_info) VALUES (?,?,?)`,
     ["2", "choices2", "additional info stuff2"]
   );
+  console.log("[TRACE]  Adding seeding data to ProductAdditionalInfos 3/3...");
   const result8 = await database.run(
     `INSERT INTO ProductAdditionalInfos (product_id, choices, additional_info) VALUES (?,?,?)`,
     ["3", "choices3", "additional info stuff3"]
@@ -164,6 +157,7 @@ export async function addDataToDatabase() {
 
 export async function dropAllTables() {
   const database = await DatabaseConnection.get();
+  console.log("[WARN] Dropping ALL TABLES from product.db");
   await database.exec(`DROP TABLE ProductAdditionalInfos;`);
   await database.exec(`DROP TABLE ProductImages;`);
   await database.exec(`DROP TABLE Products;`);

--- a/apps/graphql-api/middleware/reloader.js
+++ b/apps/graphql-api/middleware/reloader.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { DatabaseConnection } from "../database/connection.js";
-import {Request, Response, NextFunction} from "express"
+import express from "express"
 
 /**
  * Middleware to reload the DB connection if products.db has been modified.
@@ -9,15 +9,14 @@ import {Request, Response, NextFunction} from "express"
  * storage. If they do not match, a new connection is created to update it and 
  * the global variable is updated to the file's current modifiedAt time.
  * 
- * @param {Request} req 
- * @param {Response} res 
- * @param {NextFunction} next 
+ * @param {express.Request} req 
+ * @param {express.Response} res 
+ * @param {express.NextFunction} next 
  */
 const reloadOnFileChange = (req, res, next) => {
   console.log("[INFO]   Checking products.db's metadata...");
   fs.stat("/app/upload/products.db", async (err, stats) => {
     if (err) console.log(err);
-
     console.log("[TRACE]  Local update time:  ", stats.mtime.toISOString());
     console.log("[TRACE]  Stored update time: ", global.productsDbUpdatedAtTime);
 

--- a/apps/graphql-api/middleware/reloader.js
+++ b/apps/graphql-api/middleware/reloader.js
@@ -1,0 +1,30 @@
+import fs from "fs";
+import { DatabaseConnection } from "../database/connection.js";
+
+const reloadOnFileChange = (req, res, next) => {
+  console.log("[INFO]   Checking products.db's metadata...");
+  fs.stat("/app/upload/products.db", async (err, stats) => {
+    if (err) console.log(err);
+
+    console.log("[TRACE]  Local update time:  ", stats.mtime.toISOString());
+    console.log("[TRACE]  Stored update time: ", global.productsDbUpdatedAtTime);
+
+    if (stats.mtime.toISOString() !== global.productsDbUpdatedAtTime) {
+      console.log("[WARN]   The local file is out of date!");
+      console.log("[WARN]   updating DB connection...");
+      await DatabaseConnection.update();
+      console.log("[INFO]   DB connection updated");
+
+      global.productsDbUpdatedAtTime = stats.mtime.toISOString();
+      console.log("[INFO]   Stored update time updated");
+
+      console.log("[TRACE]  Stored update is now: ", global.productsDbUpdatedAtTime);
+      
+      return next();
+    }
+    console.log("[INFO]   Local file is up to date, proceeding.");
+    return next();
+  });
+};
+
+export { reloadOnFileChange };

--- a/apps/graphql-api/middleware/reloader.js
+++ b/apps/graphql-api/middleware/reloader.js
@@ -1,6 +1,18 @@
 import fs from "fs";
 import { DatabaseConnection } from "../database/connection.js";
+import {Request, Response, NextFunction} from "express"
 
+/**
+ * Middleware to reload the DB connection if products.db has been modified.
+ * 
+ * The middleware compares the global updatedAt variable with the one from file
+ * storage. If they do not match, a new connection is created to update it and 
+ * the global variable is updated to the file's current modifiedAt time.
+ * 
+ * @param {Request} req 
+ * @param {Response} res 
+ * @param {NextFunction} next 
+ */
 const reloadOnFileChange = (req, res, next) => {
   console.log("[INFO]   Checking products.db's metadata...");
   fs.stat("/app/upload/products.db", async (err, stats) => {

--- a/apps/graphql-api/middleware/reloader.js
+++ b/apps/graphql-api/middleware/reloader.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { DatabaseConnection } from "../database/connection.js";
 import express from "express"
+import { fixDbPermissions } from "../database/fixPermissions.js";
 
 /**
  * Middleware to reload the DB connection if products.db has been modified.
@@ -17,20 +18,24 @@ const reloadOnFileChange = (req, res, next) => {
   console.log("[INFO]   Checking products.db's metadata...");
   fs.stat("/app/upload/products.db", async (err, stats) => {
     if (err) console.log(err);
-    console.log("[TRACE]  Local update time:  ", stats.mtime.toISOString());
-    console.log("[TRACE]  Stored update time: ", global.productsDbUpdatedAtTime);
+    console.log("[TRACE]  File mtime:                   ", stats.mtime.toISOString());
+    console.log("[TRACE]  productsDbUpdatedAtTime time: ", global.productsDbUpdatedAtTime);
 
     if (stats.mtime.toISOString() !== global.productsDbUpdatedAtTime) {
       console.log("[WARN]   The local file is out of date!");
+
+      console.log("[TRACE]  Fixing file permissions, just in case...")
+      fixDbPermissions();
+
       console.log("[WARN]   updating DB connection...");
       await DatabaseConnection.update();
-      console.log("[INFO]   DB connection updated");
 
+      console.log("[INFO]   Updating 'productsDbUpdatedAtTime'");
       global.productsDbUpdatedAtTime = stats.mtime.toISOString();
-      console.log("[INFO]   Stored update time updated");
 
-      console.log("[TRACE]  Stored update is now: ", global.productsDbUpdatedAtTime);
-      
+      console.log("[TRACE]  'productsDbUpdatedAtTime' is now: ", global.productsDbUpdatedAtTime);
+
+      console.log(("INFO]   Update complete, proceeding."));
       return next();
     }
     console.log("[INFO]   Local file is up to date, proceeding.");

--- a/apps/graphql-api/middleware/reloader.js
+++ b/apps/graphql-api/middleware/reloader.js
@@ -6,9 +6,12 @@ import { fixDbPermissions } from "../database/fixPermissions.js";
 /**
  * Middleware to reload the DB connection if products.db has been modified.
  * 
- * The middleware compares the global updatedAt variable with the one from file
- * storage. If they do not match, a new connection is created to update it and 
- * the global variable is updated to the file's current modifiedAt time.
+ * The middleware compares the global `productsDbUpdatedAtTime` variable with 
+ * the one from file storage. If they do not match the following occurs:
+ * * The fixDbPermissions() function is run, to ensure the SFPT server can write to the file.
+ * * The DatabaseConnection is updated to ensure we are reading the updated file.
+ * * The `productsDbUpdatedAtTime` variable is updated to the current file's time.
+ * * The `next()` callback is called
  * 
  * @param {express.Request} req 
  * @param {express.Response} res 

--- a/apps/graphql-api/schema.js
+++ b/apps/graphql-api/schema.js
@@ -1,5 +1,7 @@
 import graphql from "graphql";
-import { database } from "./databaseSetup.js";
+import { DatabaseConnection } from "./database/connection.js";
+
+const database = await DatabaseConnection.get();
 
 const ProductType = new graphql.GraphQLObjectType({
   name: "Product",
@@ -160,7 +162,10 @@ const mutationType = new graphql.GraphQLObjectType({
               args.overall_rating,
             ]
           );
-          const result = await database.all("SELECT * FROM Products WHERE product_id = ?",[runQuery.lastID]);
+          const result = await database.all(
+            "SELECT * FROM Products WHERE product_id = ?",
+            [runQuery.lastID]
+          );
           resolve(result[0]);
         });
       },
@@ -199,7 +204,10 @@ const mutationType = new graphql.GraphQLObjectType({
               console.log(err);
             }
           );
-          const result = await database.all("SELECT * FROM Products WHERE product_id = ?",[args.product_id]);
+          const result = await database.all(
+            "SELECT * FROM Products WHERE product_id = ?",
+            [args.product_id]
+          );
           resolve(result[0]);
         });
       },
@@ -217,7 +225,7 @@ const mutationType = new graphql.GraphQLObjectType({
             "DELETE from Products WHERE product_id =(?);",
             [args.product_id]
           );
-          resolve('YeetusDeletus');
+          resolve("YeetusDeletus");
         });
       },
     },
@@ -242,7 +250,10 @@ const mutationType = new graphql.GraphQLObjectType({
               args.additional_info,
             ]
           );
-          const result = await database.all("SELECT * FROM ProductImages WHERE product_id = ?",[runQuery.lastID]);
+          const result = await database.all(
+            "SELECT * FROM ProductImages WHERE product_id = ?",
+            [runQuery.lastID]
+          );
           resolve(result[0]);
         });
       },
@@ -271,7 +282,10 @@ const mutationType = new graphql.GraphQLObjectType({
               args.product_image_id,
             ]
           );
-          const result = await database.all("SELECT * FROM ProductImages WHERE product_image_id = ?",[args.product_image_id]);
+          const result = await database.all(
+            "SELECT * FROM ProductImages WHERE product_image_id = ?",
+            [args.product_image_id]
+          );
           resolve(result[0]);
         });
       },
@@ -291,7 +305,7 @@ const mutationType = new graphql.GraphQLObjectType({
             "DELETE from ProductImages WHERE product_image_id =(?);",
             [args.product_image_id]
           );
-          resolve('YeetusDeletus');
+          resolve("YeetusDeletus");
         });
       },
     },
@@ -310,7 +324,10 @@ const mutationType = new graphql.GraphQLObjectType({
             "INSERT INTO ProductAdditionalInfos (product_id, choices, additional_info) VALUES (?,?,?);",
             [args.product_id, args.choices, args.additional_info]
           );
-          const result = await database.all(`SELECT * FROM ProductAdditionalInfo WHERE product_additional_info = ?`, [runQuery.lastID])
+          const result = await database.all(
+            `SELECT * FROM ProductAdditionalInfo WHERE product_additional_info = ?`,
+            [runQuery.lastID]
+          );
           resolve(result[0]);
         });
       },
@@ -337,7 +354,10 @@ const mutationType = new graphql.GraphQLObjectType({
               args.product_additional_info_id,
             ]
           );
-          const result = await database.all(`SELECT * FROM ProductAdditionalInfo WHERE product_additional_info = ?`, [args.product_additional_info_id])
+          const result = await database.all(
+            `SELECT * FROM ProductAdditionalInfo WHERE product_additional_info = ?`,
+            [args.product_additional_info_id]
+          );
           resolve(result[0]);
         });
       },
@@ -357,7 +377,7 @@ const mutationType = new graphql.GraphQLObjectType({
             "DELETE from ProductAdditionalInfo WHERE product_additional_info_id =(?);",
             [args.product_additional_info_id]
           );
-          resolve('YeetusDeletus, there goes your fetus');
+          resolve("YeetusDeletus, there goes your fetus");
         });
       },
     },

--- a/configs/graphql-api/graphql-api.dockerfile
+++ b/configs/graphql-api/graphql-api.dockerfile
@@ -18,8 +18,5 @@ RUN npm install --only-production --force
 
 COPY ./apps/graphql-api /app/
 
-
-# Install dependencies
-
 # Run the app
-ENTRYPOINT [ "npm", "start" ]
+ENTRYPOINT [ "node", "app.js" ]


### PR DESCRIPTION
# Notice to reviewer
I do not know how to send CRUD requests, so those have not been tested.

## Implementation details
Removed the old Nodemon reloading system.

At db initialization, as part of the file permissions check, I now set a global variable named: `productsDbUpdatedAtTime`.

That variable stores the current   `mtime` ( modified at time ) of the file on disk.

I also refactored how the database file is loaded by converting it into a singleton class. All usage of the connection now uses the  `.get()` function of the class to get the current instance. I also added a `.update()` method that reloads the connection.

I added a middle-ware called `reloadOnFileChange` that checks the on disk metadata for the products.db file and compares it to the value of `productsDbUpdatedAtTime`. If the file is out of date, it does the following:
1. Runs the fix permission file, just in case the passed file has bad permissions
2. Calls DatabaseConnection.update() to force everything to use the new connection instance.
3. Updates the global 'productsDbUpdatedAtTime' variable to the current file one.
4. Calls `next()`

If the file is not out of date, we just call `next()`.

## Extras
- Updated the log printouts to follow the rest of the system's convention, and added a bunch for my additions.
- Added jsdoc to the things I've added or refactored.
- Moved permission update to its own function to call it when needed

## Showcase

1. Query with empty shell of products.db. Only has the schema, no data:
![image](https://user-images.githubusercontent.com/57399961/209223879-6209fcf6-ffa8-4198-bdf3-b6c525cd76d2.png)

Logs:
![image](https://user-images.githubusercontent.com/57399961/209224019-f620efae-a429-4edf-a422-a391877230ec.png)


5. Logging into FileZilla and replacing the products.db
![image](https://user-images.githubusercontent.com/57399961/209227064-5470b967-862e-4d7d-b910-dd7f115d3f12.png)
![image](https://user-images.githubusercontent.com/57399961/209227087-850ecc34-27d2-47f6-a89d-a845983b9265.png)

6. Running the query again from the frontend
![image](https://user-images.githubusercontent.com/57399961/209227234-1f20a409-a14c-4129-9b58-179506ef7689.png)

Logs:
![image](https://user-images.githubusercontent.com/57399961/209227311-69a08779-5f03-4a8c-bfc7-f94eabfdfa5b.png)


## Showcase 2
Query with some sample data
![image](https://user-images.githubusercontent.com/57399961/209228205-ea96bd53-29be-4c79-9a37-550e5fe4ee20.png)

Logs: 
![image](https://user-images.githubusercontent.com/57399961/209228304-3279ed06-2d25-4787-8860-d0968d4aebb6.png)


After updating products.db
![image](https://user-images.githubusercontent.com/57399961/209228403-012be5da-2385-40d9-9d24-a3e5946f2ffd.png)

Logs:
![image](https://user-images.githubusercontent.com/57399961/209228462-e331d3cc-684e-4c7f-a945-045caa00e4ca.png)
